### PR TITLE
Allow usage in more contexts

### DIFF
--- a/proc-macro/src/call.rs
+++ b/proc-macro/src/call.rs
@@ -3,9 +3,7 @@
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens, TokenStreamExt};
 use std::convert::TryFrom;
-use syn::{
-    punctuated::Punctuated, token::Comma, Attribute, Expr, ExprCall, ExprMethodCall, ExprPath,
-};
+use syn::{punctuated::Punctuated, token::Comma, Expr, ExprCall, ExprMethodCall, ExprPath};
 
 /// A call expression.
 #[derive(Clone)]
@@ -17,14 +15,6 @@ pub(crate) enum Call {
 }
 
 impl Call {
-    /// Grants mutable access to the attributes of the call.
-    pub(crate) fn attrs_mut(&mut self) -> &mut Vec<Attribute> {
-        match self {
-            Call::Function(call) => &mut call.attrs,
-            Call::Method(call) => &mut call.attrs,
-        }
-    }
-
     /// Grants mutable access to the arguments of the call.
     pub(crate) fn args_mut(&mut self) -> &mut Punctuated<Expr, Comma> {
         match self {

--- a/proc-macro/src/call_handling.rs
+++ b/proc-macro/src/call_handling.rs
@@ -58,6 +58,22 @@ impl From<AssureAttr> for Precondition {
     }
 }
 
+impl Spanned for AssureAttr {
+    fn span(&self) -> Span {
+        match self {
+            AssureAttr::WithReason {
+                precondition,
+                reason,
+                ..
+            } => precondition
+                .span()
+                .join(reason.reason.span())
+                .unwrap_or_else(|| precondition.span()),
+            AssureAttr::WithoutReason { precondition, .. } => precondition.span(),
+        }
+    }
+}
+
 impl Parse for AssureAttr {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let precondition = input.parse()?;

--- a/proc-macro/src/helpers.rs
+++ b/proc-macro/src/helpers.rs
@@ -9,7 +9,7 @@ use syn::{
     parse::{Parse, ParseStream},
     spanned::Spanned,
     token::Paren,
-    Attribute,
+    Attribute, Expr,
 };
 
 lazy_static! {
@@ -97,4 +97,25 @@ impl<T: Parse> Parse for Parenthesized<T> {
             content,
         })
     }
+}
+
+/// Returns the attributes of the given expression.
+pub(crate) fn attributes_of_expression(expr: &mut Expr) -> Option<&mut Vec<Attribute>> {
+    macro_rules! extract_attributes_from {
+        ($expr:expr => $($variant:ident),*) => {
+            match $expr {
+                $(
+                Expr::$variant(e) => Some(&mut e.attrs),
+                )*
+                _ => None,
+            }
+        }
+    }
+
+    extract_attributes_from!(expr =>
+        Array, Assign, AssignOp, Async, Await, Binary, Block, Box, Break, Call, Cast,
+        Closure, Continue, Field, ForLoop, Group, If, Index, Let, Lit, Loop, Macro, Match,
+        MethodCall, Paren, Path, Range, Reference, Repeat, Return, Struct, Try, TryBlock, Tuple,
+        Type, Unary, Unsafe, While, Yield
+    )
 }

--- a/proc-macro/src/pre_attr.rs
+++ b/proc-macro/src/pre_attr.rs
@@ -8,12 +8,15 @@ use syn::{
     parse::{Parse, ParseStream},
     parse2,
     spanned::Spanned,
-    visit_mut::{visit_expr_mut, visit_file_mut, visit_item_fn_mut, visit_item_mut, VisitMut},
-    Expr, File, Item, ItemFn,
+    visit_mut::{
+        visit_expr_mut, visit_file_mut, visit_item_fn_mut, visit_item_mut, visit_local_mut,
+        VisitMut,
+    },
+    Block, Expr, File, Item, ItemFn, Local, Stmt,
 };
 
 use crate::{
-    call_handling::{remove_call_attributes, render_call},
+    call_handling::{remove_call_attributes, render_call, CallAttributes},
     helpers::{attributes_of_expression, is_attr, visit_matching_attrs_parsed, Parenthesized},
     precondition::Precondition,
     render_pre,
@@ -146,32 +149,46 @@ impl VisitMut for PreAttrVisitor {
     fn visit_expr_mut(&mut self, expr: &mut Expr) {
         visit_expr_mut(self, expr);
 
-        let attrs = if let Some(attrs) = attributes_of_expression(expr) {
-            attrs
-        } else {
-            return;
-        };
-
-        if let Some(attrs) = remove_call_attributes(attrs) {
-            if let Some(expr) = extract_call_expr(expr) {
-                let call = expr
-                    .clone()
-                    .try_into()
-                    .expect("`extract_call_expr` should only return call expressions");
-
-                mem::swap(&mut render_call(attrs, call), expr);
-            } else {
-                if let Some(forward) = attrs.forward {
-                    emit_warning!(forward.span(), "this is ignored for non-call expressions");
-                }
-
-                for assure_attribute in attrs.assure_attributes {
-                    emit_warning!(
-                        assure_attribute.span(),
-                        "this is ignored for non-call expressions"
-                    );
-                }
+        if let Some(attrs) = attributes_of_expression(expr) {
+            if let Some(call_attrs) = remove_call_attributes(attrs) {
+                render_expr(expr, call_attrs);
             }
+        }
+    }
+
+    fn visit_local_mut(&mut self, local: &mut Local) {
+        visit_local_mut(self, local);
+
+        if let Some((_, expr)) = &mut local.init {
+            if let Some(call_attrs) = remove_call_attributes(&mut local.attrs) {
+                render_expr(expr, call_attrs);
+            }
+        }
+    }
+}
+
+/// Renders the contained call in the given expression.
+///
+/// This only works, if the call can be unambiguosly determined.
+/// Otherwise warnings are printed.
+fn render_expr(expr: &mut Expr, attrs: CallAttributes) {
+    if let Some(expr) = extract_call_expr(expr) {
+        let call = expr
+            .clone()
+            .try_into()
+            .expect("`extract_call_expr` should only return call expressions");
+
+        mem::swap(&mut render_call(attrs, call), expr);
+    } else {
+        if let Some(forward) = attrs.forward {
+            emit_warning!(forward.span(), "this is ignored for non-call expressions");
+        }
+
+        for assure_attribute in attrs.assure_attributes {
+            emit_warning!(
+                assure_attribute.span(),
+                "this is ignored for non-call expressions"
+            );
         }
     }
 }
@@ -181,9 +198,112 @@ impl VisitMut for PreAttrVisitor {
 /// This may descend into nested expressions, if it would be obvious which nested expression is
 /// meant.
 fn extract_call_expr(expr: &mut Expr) -> Option<&mut Expr> {
-    match expr {
-        Expr::Call(_) => Some(expr),
-        Expr::MethodCall(_) => Some(expr),
-        _ => None,
+    fn extract_from_block(block: &mut Block) -> Option<&mut Expr> {
+        if block.stmts.len() == 1 {
+            match &mut block.stmts[0] {
+                Stmt::Local(Local {
+                    init: Some((_, expr)),
+                    ..
+                }) => extract_call_expr(expr),
+                Stmt::Local(_) => None,
+                Stmt::Item(_) => None,
+                Stmt::Expr(expr) => extract_call_expr(expr),
+                Stmt::Semi(expr, _) => extract_call_expr(expr),
+            }
+        } else {
+            None
+        }
+    }
+
+    macro_rules! find_subexpr {
+        ($expr:expr;
+         direct_return:
+             $($direct_return:ident),*;
+         subexpressions:
+             $($simple_ty:ident . $simple_field:ident),*;
+         binary_subexpressions:
+             $($binary_ty:ident : $left:ident ^ $right:ident),*;
+         optional_subexpressions:
+             $($optional_ty:ident . $optional_syn_ty:ident ? $optional_field:ident),*;
+         subblocks:
+             $($block_ty:ident . $block_name:ident),*;
+         manual:
+             $($($manual_pat:pat)|+ $(if $manual_guard:expr)? => $manual_expr:expr),* $(;)?
+        ) => {
+            match $expr {
+                // Direct return:
+                // We found a call, so return it directly
+                $(
+                    Expr::$direct_return(_) => Some($expr),
+                )*
+                // Subexpressions:
+                // There is a single unambiguos subexpression that will be searched.
+                $(
+                    Expr::$simple_ty(expr) => extract_call_expr(&mut expr.$simple_field),
+                )*
+                // Binary subexpressions:
+                // There are always exactly two subexpressions. Search them both and return the
+                // call if exactly one of them is an unambiguos call expression.
+                $(
+                    Expr::$binary_ty(expr) =>
+                    extract_call_expr(&mut expr.$left).xor(extract_call_expr(&mut expr.$right)),
+                )*
+                // Optional subexpressions:
+                // There may or may not be a subexpression. If there is one, search it.
+                $(
+                    Expr::$optional_ty(syn::$optional_syn_ty { expr: Some(expr), .. }) =>
+                    extract_call_expr(expr),
+                )*
+                // Subblocks:
+                // Search the contained block using the `extract_from_block`.
+                $(
+                    Expr::$block_ty(expr) => extract_from_block(&mut expr.$block_name),
+                )*
+                // Manual:
+                // Manually match on an expression pattern and handle it.
+                $(
+                    $($manual_pat)|+ $(if $manual_guard)? => $manual_expr,
+                )*
+                // Otherwise:
+                // Assume there is no contained call expression otherwise.
+                _ => None,
+            }
+        }
+    }
+
+    find_subexpr! { expr;
+        direct_return:
+            Call,
+            MethodCall;
+        subexpressions:
+            Await.base,
+            Box.expr,
+            Cast.expr,
+            Closure.body,
+            Field.base,
+            Group.expr,
+            Let.expr,
+            Paren.expr,
+            Reference.expr,
+            Try.expr,
+            Type.expr,
+            Unary.expr;
+        binary_subexpressions:
+            Assign: left ^ right,
+            AssignOp: left ^ right,
+            Binary: left ^ right,
+            Index: expr ^ index;
+        optional_subexpressions:
+            Break.ExprBreak ? expr,
+            Return.ExprReturn ? expr,
+            Yield.ExprYield ? expr;
+        subblocks:
+            Async.block,
+            Block.block,
+            Loop.body,
+            TryBlock.block,
+            Unsafe.block;
+        manual:
+            Expr::Tuple(expr) if expr.elems.len() == 1 => extract_call_expr(&mut expr.elems[0]);
     }
 }

--- a/proc-macro/src/pre_attr.rs
+++ b/proc-macro/src/pre_attr.rs
@@ -85,7 +85,7 @@ impl PreAttrVisitor {
         let attr_span = visit_matching_attrs_parsed(
             &mut function.attrs,
             |attr| is_attr("pre", attr),
-            |parsed_attr: Parenthesized<PreAttr>| match parsed_attr.content {
+            |parsed_attr: Parenthesized<PreAttr>, _span| match parsed_attr.content {
                 PreAttr::Empty => (),
                 PreAttr::Precondition(precondition) => preconditions.push(precondition),
             },
@@ -165,9 +165,9 @@ impl VisitMut for PreAttrVisitor {
                     emit_warning!(forward.span(), "this is ignored for non-call expressions");
                 }
 
-                for precondition in attrs.preconditions {
+                for assure_attribute in attrs.assure_attributes {
                     emit_warning!(
-                        precondition.span(),
+                        assure_attribute.span(),
                         "this is ignored for non-call expressions"
                     );
                 }

--- a/proc-macro/src/pre_attr.rs
+++ b/proc-macro/src/pre_attr.rs
@@ -14,7 +14,7 @@ use syn::{
 
 use crate::{
     call::Call,
-    call_handling::process_call,
+    call_handling::{remove_call_attributes, render_call},
     helpers::{is_attr, visit_matching_attrs_parsed, Parenthesized},
     precondition::Precondition,
     render_pre,
@@ -149,9 +149,9 @@ impl VisitMut for PreAttrVisitor {
 
         let call: Result<Call, _> = expr.clone().try_into();
 
-        if let Ok(call) = call {
-            if let Some(mut new_expr) = process_call(call) {
-                mem::swap(&mut new_expr, expr)
+        if let Ok(mut call) = call {
+            if let Some(attrs) = remove_call_attributes(call.attrs_mut()) {
+                mem::swap(&mut render_call(attrs, call), expr);
             }
         }
     }


### PR DESCRIPTION
This allows code like the following to compile now:

```rust
#[forward(std -> pre_std)]
#[assure(
    valid_ptr(src, r),
    reason = "`src` comes from reference and can therefore be read"
)]
#[assure(
    "`src` must be properly aligned for T",
    reason = "`src` comes from a reference, which is guaranteed to be aligned"
)]
#[assure(
    "`src` must point to a properly initialized value",
    reason = "`src` comes from a reference, which is guaranteed to be initialized"
)]
let x = unsafe { std::ptr::read(&5) };
```
