### PR TITLE
Fix spans for missing preconditions for unsafe

### DIFF
--- a/proc-macro/src/const_generics_impl.rs
+++ b/proc-macro/src/const_generics_impl.rs
@@ -54,7 +54,7 @@ use syn::{parse2, spanned::Spanned, Ident, ItemFn, LitStr};
 
 use crate::{
     call::Call,
-    helpers::CRATE_NAME,
+    helpers::{add_span_to_signature, CRATE_NAME},
     precondition::{Precondition, ReadWrite},
 };
 
@@ -112,12 +112,7 @@ pub(crate) fn render_pre(
 
     // Include the precondition site into the span of the function.
     // This improves the error messages for the case where no preconditions are specified.
-    function.sig.fn_token.span = function
-        .sig
-        .fn_token
-        .span
-        .join(span)
-        .unwrap_or_else(|| span);
+    add_span_to_signature(span, &mut function.sig);
 
     function.sig.inputs.push(
         parse2(quote_spanned! { span=>

--- a/proc-macro/src/helpers.rs
+++ b/proc-macro/src/helpers.rs
@@ -9,7 +9,7 @@ use syn::{
     parse::{Parse, ParseStream},
     spanned::Spanned,
     token::Paren,
-    Attribute, Expr,
+    Attribute, Expr, Signature,
 };
 
 /// The reason to display in examples on how to use reasons.
@@ -128,4 +128,27 @@ pub(crate) fn attributes_of_expression(expr: &mut Expr) -> Option<&mut Vec<Attri
         MethodCall, Paren, Path, Range, Reference, Repeat, Return, Struct, Try, TryBlock, Tuple,
         Type, Unary, Unsafe, While, Yield
     )
+}
+
+/// Incorporates the given span into the signature.
+///
+/// Ideally both are shown, when the function definition is shown.
+pub(crate) fn add_span_to_signature(span: Span, signature: &mut Signature) {
+    signature.fn_token.span = signature.fn_token.span.join(span).unwrap_or_else(|| span);
+
+    if let Some(token) = &mut signature.constness {
+        token.span = token.span.join(span).unwrap_or_else(|| span);
+    }
+
+    if let Some(token) = &mut signature.asyncness {
+        token.span = token.span.join(span).unwrap_or_else(|| span);
+    }
+
+    if let Some(token) = &mut signature.unsafety {
+        token.span = token.span.join(span).unwrap_or_else(|| span);
+    }
+
+    if let Some(abi) = &mut signature.abi {
+        abi.extern_token.span = abi.extern_token.span.join(span).unwrap_or_else(|| span);
+    }
 }

--- a/proc-macro/src/struct_impl.rs
+++ b/proc-macro/src/struct_impl.rs
@@ -67,6 +67,7 @@ use syn::{parse2, spanned::Spanned, Ident, ItemFn, PathArguments};
 
 use crate::{
     call::Call,
+    helpers::add_span_to_signature,
     precondition::{Precondition, ReadWrite},
 };
 
@@ -145,12 +146,7 @@ pub(crate) fn render_pre(
 
     // Include the precondition site into the span of the function.
     // This improves the error messages for the case where no preconditions are specified.
-    function.sig.fn_token.span = function
-        .sig
-        .fn_token
-        .span
-        .join(span)
-        .unwrap_or_else(|| span);
+    add_span_to_signature(span, &mut function.sig);
 
     function.sig.inputs.push(
         parse2(quote_spanned! { span=>

--- a/tests/nightly/function/compile_fail/missing_assure.rs
+++ b/tests/nightly/function/compile_fail/missing_assure.rs
@@ -1,9 +1,9 @@
 use pre::pre;
 
 #[pre("is bar")]
-fn foo() {}
+unsafe fn foo() {}
 
 #[pre]
 fn main() {
-    foo()
+    unsafe { foo() }
 }

--- a/tests/nightly/function/compile_fail/missing_assure.stderr
+++ b/tests/nightly/function/compile_fail/missing_assure.stderr
@@ -1,12 +1,12 @@
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
- --> $DIR/missing_assure.rs:8:5
+ --> $DIR/missing_assure.rs:8:14
   |
 3 |   #[pre("is bar")]
   |  _______-
-4 | | fn foo() {}
-  | |___________- defined here
+4 | | unsafe fn foo() {}
+  | |__________________- defined here
 ...
-8 |       foo()
-  |       ^^^-- supplied 0 arguments
-  |       |
-  |       expected 1 argument
+8 |       unsafe { foo() }
+  |                ^^^-- supplied 0 arguments
+  |                |
+  |                expected 1 argument

--- a/tests/stable/function/compile_fail/missing_assure.rs
+++ b/tests/stable/function/compile_fail/missing_assure.rs
@@ -1,9 +1,9 @@
 use pre::pre;
 
 #[pre("is bar")]
-fn foo() {}
+unsafe fn foo() {}
 
 #[pre]
 fn main() {
-    foo()
+    unsafe { foo() }
 }

--- a/tests/stable/function/compile_fail/missing_assure.stderr
+++ b/tests/stable/function/compile_fail/missing_assure.stderr
@@ -1,12 +1,12 @@
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
- --> $DIR/missing_assure.rs:8:5
+ --> $DIR/missing_assure.rs:8:14
   |
 3 |   #[pre("is bar")]
   |  _______-
-4 | | fn foo() {}
-  | |___________- defined here
+4 | | unsafe fn foo() {}
+  | |__________________- defined here
 ...
-8 |       foo()
-  |       ^^^-- supplied 0 arguments
-  |       |
-  |       expected 1 argument
+8 |       unsafe { foo() }
+  |                ^^^-- supplied 0 arguments
+  |                |
+  |                expected 1 argument

--- a/tests/templates/function/compile_fail/missing_assure.rs
+++ b/tests/templates/function/compile_fail/missing_assure.rs
@@ -1,9 +1,9 @@
 use pre::pre;
 
 #[pre("is bar")]
-fn foo() {}
+unsafe fn foo() {}
 
 #[pre]
 fn main() {
-    foo()
+    unsafe { foo() }
 }


### PR DESCRIPTION
39cfecf introduced a better error message for missing preconditions.
This did not work with `unsafe` functions before this commit. It should
now work for all function signatures.

This also changed a test to track that it works for `unsafe` functions.